### PR TITLE
User Story 2

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -9,7 +9,12 @@ class UsersController < ApplicationController
 
   def create
     user = User.new(user_params)
-    if user.save
+    # binding.pry
+    if params[:password] != params[:password_conf]
+      flash[:alert] = "Error: Mismatching passwords"
+    elsif params[:password] == nil || params[:password_conf] == nil
+      flash[:alert] = "Error: Blank password"
+    elsif user.save
       redirect_to "/users/#{user.id}"
       flash[:success] = "Welcome, #{user.name}!"
     else

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,6 +10,10 @@
   </head>
 
   <body>
+    <% flash.each do |type, notice| %>
+      <h3><b><%= notice %></b></h3>
+    <% end %>
+    
     <%= yield %>
   </body>
 </html>

--- a/spec/features/users/new_spec.rb
+++ b/spec/features/users/new_spec.rb
@@ -6,12 +6,6 @@ RSpec.describe 'new user registration page', type: :feature do
   it 'has a form to create a new user then sends user to show page' do
     visit register_path
 
-    fill_in 'Name', with: ''
-    fill_in 'Email', with: '111'
-    click_button 'Register New User'
-    expect(current_path).to eq(register_path)
-    # expect(page).to have_content 'Error:'
-
     fill_in :name, with: 'Sally'
     fill_in :email, with: 'sally@turing.com'
     fill_in 'Password', with: 'password123' 
@@ -20,5 +14,28 @@ RSpec.describe 'new user registration page', type: :feature do
     click_button 'Register New User'
 
     expect(current_path).to eq(user_path(User.last.id))
+  end
+
+  it 'takes user back to reg page if they have mismatching/blank passwords' do
+    visit register_path
+
+    fill_in :name, with: 'Sally'
+    fill_in :email, with: 'sally@turing.com'
+    fill_in 'Password', with: '' 
+    fill_in 'Password Confirmation', with: ''
+    click_button 'Register New User'
+
+    expect(current_path).to eq(register_path)
+    expect(page).to have_content "Error: Mismatching passwords"
+
+    
+    fill_in :name, with: 'Sally'
+    fill_in :email, with: 'sally@turing.com'
+    fill_in 'Password', with: '' 
+    fill_in 'Password Confirmation', with: ''
+    click_button 'Register New User'
+
+    expect(current_path).to eq(register_path)
+    expect(page).to have_content "Error: Blank password"
   end
 end


### PR DESCRIPTION
User Story #2 - Registration (w/ Authentication) Sad Path
As a visitor 
When I visit `/register`
and I fail to fill in my name, unique email, OR matching passwords,
I'm taken back to the `/register` page
and a flash message pops up, telling me what went wrong